### PR TITLE
Allow users to set canvas path properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ Here's an example:
 		drawPath: true,
 		wrapAround: true,
 		scrollBar: false,
-    		shadowBlur: 15,
-	    	shadowColor: "black",
-	    	strokeStyle: "white",
-	    	lineWidth: 10,
-	    	lineCap: "round",
-	    	lineJoin: "round"
+    	shadowBlur: 15,
+    	shadowColor: "black",
+    	strokeStyle: "white",
+    	lineWidth: 10,
+    	lineCap: "round",
+    	lineJoin: "round"
 	});
 
 Once you initialize the plugin, it will automatically center the screen to the first point in the path. While scrolling, the plugin will also always make sure that the center of the screen follows the path. Also, whenever the window is resized, the plugin makes sure it re-centers itself.

--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ Here's an example:
 		drawPath: true,
 		wrapAround: true,
 		scrollBar: false,
-    shadowBlur: 15,
-    shadowColor: "black",
-    strokeStyle: "white",
-    lineWidth: 10,
-    lineCap: "round",
-    lineJoin: "round"
+    		shadowBlur: 15,
+	    	shadowColor: "black",
+	    	strokeStyle: "white",
+	    	lineWidth: 10,
+	    	lineCap: "round",
+	    	lineJoin: "round"
 	});
 
 Once you initialize the plugin, it will automatically center the screen to the first point in the path. While scrolling, the plugin will also always make sure that the center of the screen follows the path. Also, whenever the window is resized, the plugin makes sure it re-centers itself.

--- a/README.md
+++ b/README.md
@@ -83,12 +83,32 @@ Setting `wrapAround` to 'true' will make the path loop, which means that once yo
 
 The `scrollBar` setting enables or disables the scroll bar, which is enabled by default.
 
+The following properties are all related to drawing the path, and are only relevant if `drawPath` is set to true.
+
+The `shadowBlur` setting sets the blur of the path shadow, it is 15 by default.
+
+The `shadowColor` setting sets the color of the path shadow, it is black by default.
+
+The `strokeStyle` setting sets the color of the path, it is black by default. For more information about strokeStyle see [this tutorial about strokeStyle](http://www.w3schools.com/html5/canvas_strokestyle.asp).
+
+The `lineWidth` setting sets the thickness of the path, it is 10 by default.
+
+The `lineCap` setting sets the style of the path end points, it is round by default, other options are ['butt','round','square'].
+
+The `lineJoin` setting sets the style of the path corners, it is round by default, other options are ['miter','round','bevel'].
+
 Here's an example:
 
 	$(".your-container-element").scrollPath({
 		drawPath: true,
 		wrapAround: true,
-		scrollBar: false
+		scrollBar: false,
+    shadowBlur: 15,
+    shadowColor: "black",
+    strokeStyle: "white",
+    lineWidth: 10,
+    lineCap: "round",
+    lineJoin: "round"
 	});
 
 Once you initialize the plugin, it will automatically center the screen to the first point in the path. While scrolling, the plugin will also always make sure that the center of the screen follows the path. Also, whenever the window is resized, the plugin makes sure it re-centers itself.

--- a/script/jquery.scrollpath.js
+++ b/script/jquery.scrollpath.js
@@ -45,7 +45,13 @@
 		settings = {
 			wrapAround: false,
 			drawPath: false,
-			scrollBar: true
+			scrollBar: true, 
+      shadowBlur: 15,
+      shadowColor: "black",
+      strokeStyle: "white",
+      lineWidth: 10,
+      lineCap: "round",
+      lineJoin: "round"
 		},
 
 		methods = {
@@ -380,20 +386,23 @@
 		
 		canvas[ 0 ].width = pathObject.getPathWidth();
 		canvas[ 0 ].height = pathObject.getPathHeight();
+    
+    context = canvas[ 0 ].getContext( "2d" );
+    
+    
+		context.shadowBlur = settings.shadowBlur;
+		context.shadowColor = settings.shadowColor;
+		context.strokeStyle = settings.strokeStyle;
+		context.lineJoin = settings.lineJoin;
+		context.lineCap = settings.lineCap;
+		context.lineWidth = settings.lineWidth;
 		
-		drawCanvasPath( canvas[ 0 ].getContext( "2d" ), pathObject.getCanvasPath() );
+		drawCanvasPath( context, pathObject.getCanvasPath());
 	}
 
 	/* Sets the canvas path styles and draws the path */
 	function drawCanvasPath( context, path ) {
 		var i = 0;
-
-		context.shadowBlur = 15;
-		context.shadowColor = "black";
-		context.strokeStyle = "white";
-		context.lineJoin = "round";
-		context.lineCap = "round";
-		context.lineWidth = 10;
 
 		for( ; i < path.length; i++ ) {
 			context[ path[ i ].method ].apply( context, path[ i ].args );


### PR DESCRIPTION
I passed through the canvas path drawing properties so users can customize how the path looks without changing the plugin code.
